### PR TITLE
Fix `am release` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ arcgis_map_web/assets_generator_arguments
 .buildlog/
 .history
 .svn/
+.vscode/
 
 # IntelliJ related
 *.iml

--- a/README.md
+++ b/README.md
@@ -20,17 +20,17 @@ In your app's pubspec.yaml dependencies, add:
 ```
   arcgis_map:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map
       ref: main
   arcgis_map_platform_interface:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
       ref: main
   arcgis_map_web:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_web
       ref: main
 ```

--- a/README.md
+++ b/README.md
@@ -20,17 +20,17 @@ In your app's pubspec.yaml dependencies, add:
 ```
   arcgis_map:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map
       ref: main
   arcgis_map_platform_interface:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
       ref: main
   arcgis_map_web:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_web
       ref: main
 ```

--- a/am_sidekick/lib/am_sidekick.dart
+++ b/am_sidekick/lib/am_sidekick.dart
@@ -1,17 +1,15 @@
 import 'dart:async';
 
-import 'package:am_sidekick/src/arcgis_flutter_project.dart';
+import 'package:am_sidekick/src/arcgis_map_project.dart';
 import 'package:am_sidekick/src/commands/clean_command.dart';
 import 'package:am_sidekick/src/commands/generate_arcgis_webpack.dart';
 import 'package:am_sidekick/src/commands/release/bump_version_command.dart';
 import 'package:am_sidekick/src/commands/release/edit_dependency_overrides_command.dart';
-import 'package:am_sidekick/src/commands/release/publish_command.dart';
 import 'package:am_sidekick/src/commands/release/release_command.dart';
 import 'package:am_sidekick/src/commands/test_command.dart';
 import 'package:sidekick_core/sidekick_core.dart';
 
-ArcgisFlutterProject afProject =
-    ArcgisFlutterProject(SidekickContext.projectRoot);
+ArcgisMapProject afProject = ArcgisMapProject(SidekickContext.projectRoot);
 
 Future<void> runAm(List<String> args) async {
   final runner = initializeSidekick(
@@ -29,7 +27,6 @@ Future<void> runAm(List<String> args) async {
     ..addCommand(BumpVersionCommand())
     ..addCommand(SidekickCommand())
     ..addCommand(EditDependencyOverridesCommand())
-    ..addCommand(PublishCommand())
     ..addCommand(ReleaseCommand())
     ..addCommand(TestCommand())
     ..addCommand(GenerateArcgisWebpack());

--- a/am_sidekick/lib/am_sidekick.dart
+++ b/am_sidekick/lib/am_sidekick.dart
@@ -5,6 +5,7 @@ import 'package:am_sidekick/src/commands/clean_command.dart';
 import 'package:am_sidekick/src/commands/generate_arcgis_webpack.dart';
 import 'package:am_sidekick/src/commands/release/bump_version_command.dart';
 import 'package:am_sidekick/src/commands/release/edit_dependency_overrides_command.dart';
+import 'package:am_sidekick/src/commands/release/publish_command.dart';
 import 'package:am_sidekick/src/commands/release/release_command.dart';
 import 'package:am_sidekick/src/commands/test_command.dart';
 import 'package:sidekick_core/sidekick_core.dart';
@@ -26,6 +27,7 @@ Future<void> runAm(List<String> args) async {
     ..addCommand(FormatCommand())
     ..addCommand(BumpVersionCommand())
     ..addCommand(SidekickCommand())
+    ..addCommand(PublishCommand())
     ..addCommand(EditDependencyOverridesCommand())
     ..addCommand(ReleaseCommand())
     ..addCommand(TestCommand())

--- a/am_sidekick/lib/src/arcgis_map_project.dart
+++ b/am_sidekick/lib/src/arcgis_map_project.dart
@@ -1,7 +1,7 @@
 import 'package:sidekick_core/sidekick_core.dart';
 
-class ArcgisFlutterProject {
-  ArcgisFlutterProject(this.root);
+class ArcgisMapProject {
+  ArcgisMapProject(this.root);
 
   final Directory root;
 
@@ -18,8 +18,17 @@ class ArcgisFlutterProject {
   DartPackage get arcgisMapWeb =>
       DartPackage.fromDirectory(root.directory('arcgis_map_web'))!;
 
-  DartPackage get afSidekickPackage =>
-      DartPackage.fromDirectory(root.directory('af_sidekick'))!;
+  DartPackage get arcgisMapAndroid =>
+      DartPackage.fromDirectory(root.directory('arcgis_map_android'))!;
+
+  DartPackage get arcgisMapIos =>
+      DartPackage.fromDirectory(root.directory('arcgis_map_ios'))!;
+
+  DartPackage get arcgisMapMethodChannel =>
+      DartPackage.fromDirectory(root.directory('arcgis_map_method_channel'))!;
+
+  DartPackage get amSidekickPackage =>
+      DartPackage.fromDirectory(root.directory('am_sidekick'))!;
 
   File get flutterw => root.file('flutterw');
 

--- a/am_sidekick/lib/src/commands/release/bump_version_command.dart
+++ b/am_sidekick/lib/src/commands/release/bump_version_command.dart
@@ -23,7 +23,7 @@ final versionOption = CliOption(
 
 class BumpVersionCommand extends Command {
   @override
-  final String description = 'Bumps the arcgis_flutter version';
+  final String description = 'Bumps the arcgis_map version';
 
   @override
   final String name = 'bump-version';
@@ -81,6 +81,9 @@ class BumpVersionCommand extends Command {
       afProject.arcgisMap,
       afProject.arcgisMapPlatformInterface,
       afProject.arcgisMapWeb,
+      afProject.arcgisMapAndroid,
+      afProject.arcgisMapIos,
+      afProject.arcgisMapMethodChannel,
     };
     for (final package in packages) {
       final pubspecFile = package.pubspec;
@@ -137,7 +140,7 @@ class BumpVersionCommand extends Command {
       /// save to disk
       pubspecFile.replaceFirst(version.toString(), newVersion.toString());
       print(
-        'Arcgis_flutter version bumped from ${yellow(version.toString())} => ${green(newVersion.toString())}',
+        'Arcgis_map version bumped from ${yellow(version.toString())} => ${green(newVersion.toString())}',
       );
     }
   }

--- a/am_sidekick/lib/src/commands/release/edit_dependency_overrides_command.dart
+++ b/am_sidekick/lib/src/commands/release/edit_dependency_overrides_command.dart
@@ -36,6 +36,9 @@ class EditDependencyOverridesCommand extends Command {
       afProject.arcgisMap.pubspec,
       afProject.arcgisMapPlatformInterface.pubspec,
       afProject.arcgisMapWeb.pubspec,
+      afProject.arcgisMapAndroid.pubspec,
+      afProject.arcgisMapIos.pubspec,
+      afProject.arcgisMapMethodChannel.pubspec,
     };
 
     for (final pubspecFile in pubspecFiles) {

--- a/am_sidekick/lib/src/commands/release/publish_command.dart
+++ b/am_sidekick/lib/src/commands/release/publish_command.dart
@@ -60,7 +60,7 @@ class PublishCommand extends Command {
     areThereStagedFiles = allFilesDiff.exitCode != 0;
 
     if (areThereStagedFiles) {
-      error(red('There are stages files, not committing version bump'));
+      error(red('There are staged files, not committing version bump'));
     }
 
     final detachedHEAD = 'git symbolic-ref -q HEAD'

--- a/am_sidekick/lib/src/commands/release/publish_command.dart
+++ b/am_sidekick/lib/src/commands/release/publish_command.dart
@@ -11,10 +11,10 @@ final dryRunFlag = CliFlag(
 class PublishCommand extends Command {
   @override
   final String description =
-      'Commits & tags the new version and releases the kraken!';
+      'Commits & tags the new version and pushes it to origin.';
 
   @override
-  final String name = 'release-the-kraken';
+  final String name = 'publish';
 
   /// List of all flags and options
   static final List<CliBabo> options = [dryRunFlag];
@@ -40,6 +40,9 @@ class PublishCommand extends Command {
       afProject.arcgisMapExample,
       afProject.arcgisMapPlatformInterface,
       afProject.arcgisMapWeb,
+      afProject.arcgisMapAndroid,
+      afProject.arcgisMapIos,
+      afProject.arcgisMapMethodChannel,
     };
 
     /// Get the version from the pubspec to tag

--- a/am_sidekick/lib/src/commands/release/release_command.dart
+++ b/am_sidekick/lib/src/commands/release/release_command.dart
@@ -6,13 +6,9 @@ import 'package:sidekick_core/sidekick_core.dart';
 
 class ReleaseCommand extends Command {
   @override
-  final String description = "Release me, release my body. "
-      "I know it's wrong, "
-      "So why am I with you now? "
-      "I say release me. "
-      "Cause I'm not able to convince myself. "
-      "That I'm better off without you. "
-      "---- Releases new version of a package ----";
+  final String description = "Releases new version of a package. "
+      "This will create a new tag and commit the changes "
+      "to the current branch!";
 
   @override
   final String name = 'release';
@@ -70,7 +66,7 @@ class ReleaseCommand extends Command {
 
     /// Let it rip!
     await runAm(
-      ['release-the-kraken', dryRunFlag.asCommandlineArg(argResults)],
+      ['publish', dryRunFlag.asCommandlineArg(argResults)],
     );
     print(orange('Tag/commit stage done'));
     print('');

--- a/arcgis_map/example/README.md
+++ b/arcgis_map/example/README.md
@@ -9,12 +9,12 @@ In your app's pubspec.yaml dependencies, add e.g. for web:
 ```
   arcgis_map:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map
       ref: main
   arcgis_map_web:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_web
       ref: main
 ```

--- a/arcgis_map/example/README.md
+++ b/arcgis_map/example/README.md
@@ -9,12 +9,12 @@ In your app's pubspec.yaml dependencies, add e.g. for web:
 ```
   arcgis_map:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map
       ref: main
   arcgis_map_web:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_web
       ref: main
 ```

--- a/arcgis_map/example/pubspec.lock
+++ b/arcgis_map/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: arcgis_map
       ref: "v0.7.4"
       resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
-      url: "git@github.com:fluttercommunity/arcgis_map.git"
+      url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.4"
   arcgis_map_android:
@@ -16,7 +16,7 @@ packages:
       path: arcgis_map_android
       ref: "v0.7.4"
       resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
-      url: "git@github.com:fluttercommunity/arcgis_map.git"
+      url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.4"
   arcgis_map_ios:
@@ -25,7 +25,7 @@ packages:
       path: arcgis_map_ios
       ref: "v0.7.4"
       resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
-      url: "git@github.com:fluttercommunity/arcgis_map.git"
+      url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.4"
   arcgis_map_method_channel:
@@ -34,7 +34,7 @@ packages:
       path: arcgis_map_method_channel
       ref: "v0.7.4"
       resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
-      url: "git@github.com:fluttercommunity/arcgis_map.git"
+      url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.4"
   arcgis_map_platform_interface:
@@ -43,7 +43,7 @@ packages:
       path: arcgis_map_platform_interface
       ref: "v0.7.4"
       resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
-      url: "git@github.com:fluttercommunity/arcgis_map.git"
+      url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.4"
   arcgis_map_web:
@@ -52,7 +52,7 @@ packages:
       path: arcgis_map_web
       ref: "v0.7.4"
       resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
-      url: "git@github.com:fluttercommunity/arcgis_map.git"
+      url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.4"
   async:

--- a/arcgis_map/example/pubspec.lock
+++ b/arcgis_map/example/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.7.0"
   arcgis_map_android:
     dependency: "direct overridden"
     description:
       path: "../../arcgis_map_android"
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.7.0"
   arcgis_map_ios:
     dependency: "direct overridden"
     description:
       path: "../../arcgis_map_ios"
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.7.0"
   arcgis_map_method_channel:
     dependency: "direct overridden"
     description:
       path: "../../arcgis_map_method_channel"
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.7.0"
   arcgis_map_platform_interface:
     dependency: "direct main"
     description:
       path: "../../arcgis_map_platform_interface"
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.7.0"
   arcgis_map_web:
     dependency: "direct main"
     description:
       path: "../../arcgis_map_web"
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.7.0"
   async:
     dependency: transitive
     description:

--- a/arcgis_map/example/pubspec.lock
+++ b/arcgis_map/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: arcgis_map
       ref: "v0.7.3"
       resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
-      url: "git@github.com:phntmxyz/arcgis_map.git"
+      url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.3"
   arcgis_map_android:
@@ -16,7 +16,7 @@ packages:
       path: arcgis_map_android
       ref: "v0.7.3"
       resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
-      url: "git@github.com:phntmxyz/arcgis_map.git"
+      url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.3"
   arcgis_map_ios:
@@ -25,7 +25,7 @@ packages:
       path: arcgis_map_ios
       ref: "v0.7.3"
       resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
-      url: "git@github.com:phntmxyz/arcgis_map.git"
+      url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.3"
   arcgis_map_method_channel:
@@ -34,7 +34,7 @@ packages:
       path: arcgis_map_method_channel
       ref: "v0.7.3"
       resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
-      url: "git@github.com:phntmxyz/arcgis_map.git"
+      url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.3"
   arcgis_map_platform_interface:
@@ -43,7 +43,7 @@ packages:
       path: arcgis_map_platform_interface
       ref: "v0.7.3"
       resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
-      url: "git@github.com:phntmxyz/arcgis_map.git"
+      url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.3"
   arcgis_map_web:
@@ -52,7 +52,7 @@ packages:
       path: arcgis_map_web
       ref: "v0.7.3"
       resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
-      url: "git@github.com:phntmxyz/arcgis_map.git"
+      url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.3"
   async:

--- a/arcgis_map/example/pubspec.lock
+++ b/arcgis_map/example/pubspec.lock
@@ -5,56 +5,56 @@ packages:
     dependency: "direct main"
     description:
       path: arcgis_map
-      ref: "v0.7.3"
-      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      ref: "v0.7.4"
+      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
       url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.3"
+    version: "0.7.4"
   arcgis_map_android:
     dependency: "direct main"
     description:
       path: arcgis_map_android
-      ref: "v0.7.3"
-      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      ref: "v0.7.4"
+      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
       url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.3"
+    version: "0.7.4"
   arcgis_map_ios:
     dependency: "direct main"
     description:
       path: arcgis_map_ios
-      ref: "v0.7.3"
-      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      ref: "v0.7.4"
+      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
       url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.3"
+    version: "0.7.4"
   arcgis_map_method_channel:
     dependency: "direct main"
     description:
       path: arcgis_map_method_channel
-      ref: "v0.7.3"
-      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      ref: "v0.7.4"
+      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
       url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.3"
+    version: "0.7.4"
   arcgis_map_platform_interface:
     dependency: "direct main"
     description:
       path: arcgis_map_platform_interface
-      ref: "v0.7.3"
-      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      ref: "v0.7.4"
+      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
       url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.3"
+    version: "0.7.4"
   arcgis_map_web:
     dependency: "direct main"
     description:
       path: arcgis_map_web
-      ref: "v0.7.3"
-      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      ref: "v0.7.4"
+      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
       url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.3"
+    version: "0.7.4"
   async:
     dependency: transitive
     description:

--- a/arcgis_map/example/pubspec.lock
+++ b/arcgis_map/example/pubspec.lock
@@ -5,56 +5,56 @@ packages:
     dependency: "direct main"
     description:
       path: arcgis_map
-      ref: "v0.7.4"
-      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
+      ref: "v0.7.5"
+      resolved-ref: f6f96a5fc8212c6b1700aa3b301cbffc388e197e
       url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.4"
+    version: "0.7.5"
   arcgis_map_android:
     dependency: "direct main"
     description:
       path: arcgis_map_android
-      ref: "v0.7.4"
-      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
+      ref: "v0.7.5"
+      resolved-ref: f6f96a5fc8212c6b1700aa3b301cbffc388e197e
       url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.4"
+    version: "0.7.5"
   arcgis_map_ios:
     dependency: "direct main"
     description:
       path: arcgis_map_ios
-      ref: "v0.7.4"
-      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
+      ref: "v0.7.5"
+      resolved-ref: f6f96a5fc8212c6b1700aa3b301cbffc388e197e
       url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.4"
+    version: "0.7.5"
   arcgis_map_method_channel:
     dependency: "direct main"
     description:
       path: arcgis_map_method_channel
-      ref: "v0.7.4"
-      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
+      ref: "v0.7.5"
+      resolved-ref: f6f96a5fc8212c6b1700aa3b301cbffc388e197e
       url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.4"
+    version: "0.7.5"
   arcgis_map_platform_interface:
     dependency: "direct main"
     description:
       path: arcgis_map_platform_interface
-      ref: "v0.7.4"
-      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
+      ref: "v0.7.5"
+      resolved-ref: f6f96a5fc8212c6b1700aa3b301cbffc388e197e
       url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.4"
+    version: "0.7.5"
   arcgis_map_web:
     dependency: "direct main"
     description:
       path: arcgis_map_web
-      ref: "v0.7.4"
-      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
+      ref: "v0.7.5"
+      resolved-ref: f6f96a5fc8212c6b1700aa3b301cbffc388e197e
       url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.4"
+    version: "0.7.5"
   async:
     dependency: transitive
     description:

--- a/arcgis_map/example/pubspec.lock
+++ b/arcgis_map/example/pubspec.lock
@@ -9,21 +9,21 @@ packages:
     source: path
     version: "0.7.0"
   arcgis_map_android:
-    dependency: "direct overridden"
+    dependency: "direct main"
     description:
       path: "../../arcgis_map_android"
       relative: true
     source: path
     version: "0.7.0"
   arcgis_map_ios:
-    dependency: "direct overridden"
+    dependency: "direct main"
     description:
       path: "../../arcgis_map_ios"
       relative: true
     source: path
     version: "0.7.0"
   arcgis_map_method_channel:
-    dependency: "direct overridden"
+    dependency: "direct main"
     description:
       path: "../../arcgis_map_method_channel"
       relative: true

--- a/arcgis_map/example/pubspec.lock
+++ b/arcgis_map/example/pubspec.lock
@@ -4,45 +4,57 @@ packages:
   arcgis_map:
     dependency: "direct main"
     description:
-      path: ".."
-      relative: true
-    source: path
-    version: "0.7.0"
+      path: arcgis_map
+      ref: "v0.7.3"
+      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      url: "git@github.com:phntmxyz/arcgis_map.git"
+    source: git
+    version: "0.7.3"
   arcgis_map_android:
     dependency: "direct main"
     description:
-      path: "../../arcgis_map_android"
-      relative: true
-    source: path
-    version: "0.7.0"
+      path: arcgis_map_android
+      ref: "v0.7.3"
+      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      url: "git@github.com:phntmxyz/arcgis_map.git"
+    source: git
+    version: "0.7.3"
   arcgis_map_ios:
     dependency: "direct main"
     description:
-      path: "../../arcgis_map_ios"
-      relative: true
-    source: path
-    version: "0.7.0"
+      path: arcgis_map_ios
+      ref: "v0.7.3"
+      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      url: "git@github.com:phntmxyz/arcgis_map.git"
+    source: git
+    version: "0.7.3"
   arcgis_map_method_channel:
     dependency: "direct main"
     description:
-      path: "../../arcgis_map_method_channel"
-      relative: true
-    source: path
-    version: "0.7.0"
+      path: arcgis_map_method_channel
+      ref: "v0.7.3"
+      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      url: "git@github.com:phntmxyz/arcgis_map.git"
+    source: git
+    version: "0.7.3"
   arcgis_map_platform_interface:
     dependency: "direct main"
     description:
-      path: "../../arcgis_map_platform_interface"
-      relative: true
-    source: path
-    version: "0.7.0"
+      path: arcgis_map_platform_interface
+      ref: "v0.7.3"
+      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      url: "git@github.com:phntmxyz/arcgis_map.git"
+    source: git
+    version: "0.7.3"
   arcgis_map_web:
     dependency: "direct main"
     description:
-      path: "../../arcgis_map_web"
-      relative: true
-    source: path
-    version: "0.7.0"
+      path: arcgis_map_web
+      ref: "v0.7.3"
+      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      url: "git@github.com:phntmxyz/arcgis_map.git"
+    source: git
+    version: "0.7.3"
   async:
     dependency: transitive
     description:

--- a/arcgis_map/example/pubspec.yaml
+++ b/arcgis_map/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: An example app with the ArcGIS package implementation.
 
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 0.7.4
+version: 0.7.5
 
 environment:
   sdk: ">=2.17.0 <4.0.0"
@@ -13,32 +13,32 @@ dependencies:
     git:
       url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map
-      ref: v0.7.4
+      ref: v0.7.5
   arcgis_map_android:
     git:
       url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_android
-      ref: v0.7.4
+      ref: v0.7.5
   arcgis_map_ios:
     git:
       url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_ios
-      ref: v0.7.4
+      ref: v0.7.5
   arcgis_map_method_channel:
     git:
       url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_method_channel
-      ref: v0.7.4
+      ref: v0.7.5
   arcgis_map_platform_interface:
     git:
       url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.4
+      ref: v0.7.5
   arcgis_map_web:
     git:
       url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_web
-      ref: v0.7.4
+      ref: v0.7.5
 
   cupertino_icons: ^1.0.0
   flutter:

--- a/arcgis_map/example/pubspec.yaml
+++ b/arcgis_map/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: An example app with the ArcGIS package implementation.
 
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.0+1
+version: 0.7.0
 
 environment:
   sdk: ">=2.17.0 <4.0.0"
@@ -13,17 +13,17 @@ dependencies:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map
-      ref: main
+      ref: v0.7.0
   arcgis_map_platform_interface:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: main
+      ref: 0.7.0
   arcgis_map_web:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_web
-      ref: main
+      ref: 0.7.0
 
   cupertino_icons: ^1.0.0
   flutter:

--- a/arcgis_map/example/pubspec.yaml
+++ b/arcgis_map/example/pubspec.yaml
@@ -11,32 +11,32 @@ environment:
 dependencies:
   arcgis_map:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map
       ref: v0.7.3
   arcgis_map_android:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_android
       ref: v0.7.3
   arcgis_map_ios:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_ios
       ref: v0.7.3
   arcgis_map_method_channel:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_method_channel
       ref: v0.7.3
   arcgis_map_platform_interface:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
       ref: v0.7.3
   arcgis_map_web:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_web
       ref: v0.7.3
 

--- a/arcgis_map/example/pubspec.yaml
+++ b/arcgis_map/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: An example app with the ArcGIS package implementation.
 
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 0.7.0
+version: 0.7.1
 
 environment:
   sdk: ">=2.17.0 <4.0.0"
@@ -13,32 +13,32 @@ dependencies:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map
-      ref: v0.7.0
+      ref: v0.7.1
   arcgis_map_android:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_android
-      ref: 0.7.0
+      ref: v0.7.1
   arcgis_map_ios:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_ios
-      ref: 0.7.0
+      ref: v0.7.1
   arcgis_map_method_channel:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_method_channel
-      ref: 0.7.0
+      ref: v0.7.1
   arcgis_map_platform_interface:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: 0.7.0
+      ref: v0.7.1
   arcgis_map_web:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_web
-      ref: 0.7.0
+      ref: v0.7.1
 
   cupertino_icons: ^1.0.0
   flutter:
@@ -53,19 +53,6 @@ dev_dependencies:
   lint: ^2.0.0
 
 # Used to work locally on the package
-dependency_overrides:
-  arcgis_map:
-    path: ../../arcgis_map
-  arcgis_map_android:
-    path: ../../arcgis_map_android
-  arcgis_map_ios:
-    path: ../../arcgis_map_ios
-  arcgis_map_method_channel:
-    path: ../../arcgis_map_method_channel
-  arcgis_map_platform_interface:
-    path: ../../arcgis_map_platform_interface
-  arcgis_map_web:
-    path: ../../arcgis_map_web
 
 
 flutter:

--- a/arcgis_map/example/pubspec.yaml
+++ b/arcgis_map/example/pubspec.yaml
@@ -11,32 +11,32 @@ environment:
 dependencies:
   arcgis_map:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map
       ref: v0.7.4
   arcgis_map_android:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_android
       ref: v0.7.4
   arcgis_map_ios:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_ios
       ref: v0.7.4
   arcgis_map_method_channel:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_method_channel
       ref: v0.7.4
   arcgis_map_platform_interface:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
       ref: v0.7.4
   arcgis_map_web:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_web
       ref: v0.7.4
 

--- a/arcgis_map/example/pubspec.yaml
+++ b/arcgis_map/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: An example app with the ArcGIS package implementation.
 
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 0.7.1
+version: 0.7.3
 
 environment:
   sdk: ">=2.17.0 <4.0.0"
@@ -13,32 +13,32 @@ dependencies:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map
-      ref: v0.7.1
+      ref: v0.7.3
   arcgis_map_android:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_android
-      ref: v0.7.1
+      ref: v0.7.3
   arcgis_map_ios:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_ios
-      ref: v0.7.1
+      ref: v0.7.3
   arcgis_map_method_channel:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_method_channel
-      ref: v0.7.1
+      ref: v0.7.3
   arcgis_map_platform_interface:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.1
+      ref: v0.7.3
   arcgis_map_web:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_web
-      ref: v0.7.1
+      ref: v0.7.3
 
   cupertino_icons: ^1.0.0
   flutter:

--- a/arcgis_map/example/pubspec.yaml
+++ b/arcgis_map/example/pubspec.yaml
@@ -14,6 +14,21 @@ dependencies:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map
       ref: v0.7.0
+  arcgis_map_android:
+    git:
+      url: git@github.com:phntmxyz/arcgis_map.git
+      path: arcgis_map_android
+      ref: 0.7.0
+  arcgis_map_ios:
+    git:
+      url: git@github.com:phntmxyz/arcgis_map.git
+      path: arcgis_map_ios
+      ref: 0.7.0
+  arcgis_map_method_channel:
+    git:
+      url: git@github.com:phntmxyz/arcgis_map.git
+      path: arcgis_map_method_channel
+      ref: 0.7.0
   arcgis_map_platform_interface:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git

--- a/arcgis_map/example/pubspec.yaml
+++ b/arcgis_map/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: An example app with the ArcGIS package implementation.
 
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 0.7.1
+version: 1.0.0+1
 
 environment:
   sdk: ">=2.17.0 <4.0.0"
@@ -13,17 +13,17 @@ dependencies:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map
-      ref: v0.7.1
+      ref: main
   arcgis_map_platform_interface:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.1
+      ref: main
   arcgis_map_web:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_web
-      ref: v0.7.1
+      ref: main
 
   cupertino_icons: ^1.0.0
   flutter:
@@ -38,6 +38,19 @@ dev_dependencies:
   lint: ^2.0.0
 
 # Used to work locally on the package
+dependency_overrides:
+  arcgis_map:
+    path: ../../arcgis_map
+  arcgis_map_android:
+    path: ../../arcgis_map_android
+  arcgis_map_ios:
+    path: ../../arcgis_map_ios
+  arcgis_map_method_channel:
+    path: ../../arcgis_map_method_channel
+  arcgis_map_platform_interface:
+    path: ../../arcgis_map_platform_interface
+  arcgis_map_web:
+    path: ../../arcgis_map_web
 
 
 flutter:

--- a/arcgis_map/example/pubspec.yaml
+++ b/arcgis_map/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: An example app with the ArcGIS package implementation.
 
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 0.7.3
+version: 0.7.4
 
 environment:
   sdk: ">=2.17.0 <4.0.0"
@@ -13,32 +13,32 @@ dependencies:
     git:
       url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map
-      ref: v0.7.3
+      ref: v0.7.4
   arcgis_map_android:
     git:
       url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_android
-      ref: v0.7.3
+      ref: v0.7.4
   arcgis_map_ios:
     git:
       url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_ios
-      ref: v0.7.3
+      ref: v0.7.4
   arcgis_map_method_channel:
     git:
       url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_method_channel
-      ref: v0.7.3
+      ref: v0.7.4
   arcgis_map_platform_interface:
     git:
       url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.3
+      ref: v0.7.4
   arcgis_map_web:
     git:
       url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_web
-      ref: v0.7.3
+      ref: v0.7.4
 
   cupertino_icons: ^1.0.0
   flutter:

--- a/arcgis_map/pubspec.lock
+++ b/arcgis_map/pubspec.lock
@@ -4,38 +4,48 @@ packages:
   arcgis_map_android:
     dependency: "direct main"
     description:
-      path: "../arcgis_map_android"
-      relative: true
-    source: path
-    version: "0.7.0"
+      path: arcgis_map_android
+      ref: "v0.7.3"
+      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      url: "git@github.com:phntmxyz/arcgis_map.git"
+    source: git
+    version: "0.7.3"
   arcgis_map_ios:
     dependency: "direct main"
     description:
-      path: "../arcgis_map_ios"
-      relative: true
-    source: path
-    version: "0.7.0"
+      path: arcgis_map_ios
+      ref: "v0.7.3"
+      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      url: "git@github.com:phntmxyz/arcgis_map.git"
+    source: git
+    version: "0.7.3"
   arcgis_map_method_channel:
     dependency: "direct main"
     description:
-      path: "../arcgis_map_method_channel"
-      relative: true
-    source: path
-    version: "0.7.0"
+      path: arcgis_map_method_channel
+      ref: "v0.7.3"
+      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      url: "git@github.com:phntmxyz/arcgis_map.git"
+    source: git
+    version: "0.7.3"
   arcgis_map_platform_interface:
     dependency: "direct main"
     description:
-      path: "../arcgis_map_platform_interface"
-      relative: true
-    source: path
-    version: "0.7.0"
+      path: arcgis_map_platform_interface
+      ref: "v0.7.3"
+      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      url: "git@github.com:phntmxyz/arcgis_map.git"
+    source: git
+    version: "0.7.3"
   arcgis_map_web:
     dependency: "direct main"
     description:
-      path: "../arcgis_map_web"
-      relative: true
-    source: path
-    version: "0.7.0"
+      path: arcgis_map_web
+      ref: "v0.7.3"
+      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      url: "git@github.com:phntmxyz/arcgis_map.git"
+    source: git
+    version: "0.7.3"
   async:
     dependency: transitive
     description:

--- a/arcgis_map/pubspec.lock
+++ b/arcgis_map/pubspec.lock
@@ -7,35 +7,35 @@ packages:
       path: "../arcgis_map_android"
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.7.0"
   arcgis_map_ios:
     dependency: "direct main"
     description:
       path: "../arcgis_map_ios"
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.7.0"
   arcgis_map_method_channel:
     dependency: "direct overridden"
     description:
       path: "../arcgis_map_method_channel"
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.7.0"
   arcgis_map_platform_interface:
     dependency: "direct main"
     description:
       path: "../arcgis_map_platform_interface"
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.7.0"
   arcgis_map_web:
     dependency: "direct overridden"
     description:
       path: "../arcgis_map_web"
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.7.0"
   async:
     dependency: transitive
     description:

--- a/arcgis_map/pubspec.lock
+++ b/arcgis_map/pubspec.lock
@@ -5,47 +5,47 @@ packages:
     dependency: "direct main"
     description:
       path: arcgis_map_android
-      ref: "v0.7.4"
-      resolved-ref: "17d77d49d1c211f6389a0f0dc6c3acf23c21aeb0"
+      ref: "v0.7.5"
+      resolved-ref: f6f96a5fc8212c6b1700aa3b301cbffc388e197e
       url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.4"
+    version: "0.7.5"
   arcgis_map_ios:
     dependency: "direct main"
     description:
       path: arcgis_map_ios
-      ref: "v0.7.4"
-      resolved-ref: "17d77d49d1c211f6389a0f0dc6c3acf23c21aeb0"
+      ref: "v0.7.5"
+      resolved-ref: f6f96a5fc8212c6b1700aa3b301cbffc388e197e
       url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.4"
+    version: "0.7.5"
   arcgis_map_method_channel:
     dependency: "direct main"
     description:
       path: arcgis_map_method_channel
-      ref: "v0.7.4"
-      resolved-ref: "17d77d49d1c211f6389a0f0dc6c3acf23c21aeb0"
+      ref: "v0.7.5"
+      resolved-ref: f6f96a5fc8212c6b1700aa3b301cbffc388e197e
       url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.4"
+    version: "0.7.5"
   arcgis_map_platform_interface:
     dependency: "direct main"
     description:
       path: arcgis_map_platform_interface
-      ref: "v0.7.4"
-      resolved-ref: "17d77d49d1c211f6389a0f0dc6c3acf23c21aeb0"
+      ref: "v0.7.5"
+      resolved-ref: f6f96a5fc8212c6b1700aa3b301cbffc388e197e
       url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.4"
+    version: "0.7.5"
   arcgis_map_web:
     dependency: "direct main"
     description:
       path: arcgis_map_web
-      ref: "v0.7.4"
-      resolved-ref: "17d77d49d1c211f6389a0f0dc6c3acf23c21aeb0"
+      ref: "v0.7.5"
+      resolved-ref: f6f96a5fc8212c6b1700aa3b301cbffc388e197e
       url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.4"
+    version: "0.7.5"
   async:
     dependency: transitive
     description:

--- a/arcgis_map/pubspec.lock
+++ b/arcgis_map/pubspec.lock
@@ -5,47 +5,47 @@ packages:
     dependency: "direct main"
     description:
       path: arcgis_map_android
-      ref: "v0.7.3"
-      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      ref: "v0.7.4"
+      resolved-ref: "17d77d49d1c211f6389a0f0dc6c3acf23c21aeb0"
       url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.3"
+    version: "0.7.4"
   arcgis_map_ios:
     dependency: "direct main"
     description:
       path: arcgis_map_ios
-      ref: "v0.7.3"
-      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      ref: "v0.7.4"
+      resolved-ref: "17d77d49d1c211f6389a0f0dc6c3acf23c21aeb0"
       url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.3"
+    version: "0.7.4"
   arcgis_map_method_channel:
     dependency: "direct main"
     description:
       path: arcgis_map_method_channel
-      ref: "v0.7.3"
-      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      ref: "v0.7.4"
+      resolved-ref: "17d77d49d1c211f6389a0f0dc6c3acf23c21aeb0"
       url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.3"
+    version: "0.7.4"
   arcgis_map_platform_interface:
     dependency: "direct main"
     description:
       path: arcgis_map_platform_interface
-      ref: "v0.7.3"
-      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      ref: "v0.7.4"
+      resolved-ref: "17d77d49d1c211f6389a0f0dc6c3acf23c21aeb0"
       url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.3"
+    version: "0.7.4"
   arcgis_map_web:
     dependency: "direct main"
     description:
       path: arcgis_map_web
-      ref: "v0.7.3"
-      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      ref: "v0.7.4"
+      resolved-ref: "17d77d49d1c211f6389a0f0dc6c3acf23c21aeb0"
       url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.3"
+    version: "0.7.4"
   async:
     dependency: transitive
     description:

--- a/arcgis_map/pubspec.lock
+++ b/arcgis_map/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: arcgis_map_android
       ref: "v0.7.3"
       resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
-      url: "git@github.com:phntmxyz/arcgis_map.git"
+      url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.3"
   arcgis_map_ios:
@@ -16,7 +16,7 @@ packages:
       path: arcgis_map_ios
       ref: "v0.7.3"
       resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
-      url: "git@github.com:phntmxyz/arcgis_map.git"
+      url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.3"
   arcgis_map_method_channel:
@@ -25,7 +25,7 @@ packages:
       path: arcgis_map_method_channel
       ref: "v0.7.3"
       resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
-      url: "git@github.com:phntmxyz/arcgis_map.git"
+      url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.3"
   arcgis_map_platform_interface:
@@ -34,7 +34,7 @@ packages:
       path: arcgis_map_platform_interface
       ref: "v0.7.3"
       resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
-      url: "git@github.com:phntmxyz/arcgis_map.git"
+      url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.3"
   arcgis_map_web:
@@ -43,7 +43,7 @@ packages:
       path: arcgis_map_web
       ref: "v0.7.3"
       resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
-      url: "git@github.com:phntmxyz/arcgis_map.git"
+      url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.3"
   async:

--- a/arcgis_map/pubspec.lock
+++ b/arcgis_map/pubspec.lock
@@ -16,7 +16,7 @@ packages:
     source: path
     version: "0.7.0"
   arcgis_map_method_channel:
-    dependency: "direct overridden"
+    dependency: "direct main"
     description:
       path: "../arcgis_map_method_channel"
       relative: true
@@ -30,7 +30,7 @@ packages:
     source: path
     version: "0.7.0"
   arcgis_map_web:
-    dependency: "direct overridden"
+    dependency: "direct main"
     description:
       path: "../arcgis_map_web"
       relative: true

--- a/arcgis_map/pubspec.lock
+++ b/arcgis_map/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: arcgis_map_android
       ref: "v0.7.4"
       resolved-ref: "17d77d49d1c211f6389a0f0dc6c3acf23c21aeb0"
-      url: "git@github.com:fluttercommunity/arcgis_map.git"
+      url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.4"
   arcgis_map_ios:
@@ -16,7 +16,7 @@ packages:
       path: arcgis_map_ios
       ref: "v0.7.4"
       resolved-ref: "17d77d49d1c211f6389a0f0dc6c3acf23c21aeb0"
-      url: "git@github.com:fluttercommunity/arcgis_map.git"
+      url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.4"
   arcgis_map_method_channel:
@@ -25,7 +25,7 @@ packages:
       path: arcgis_map_method_channel
       ref: "v0.7.4"
       resolved-ref: "17d77d49d1c211f6389a0f0dc6c3acf23c21aeb0"
-      url: "git@github.com:fluttercommunity/arcgis_map.git"
+      url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.4"
   arcgis_map_platform_interface:
@@ -34,7 +34,7 @@ packages:
       path: arcgis_map_platform_interface
       ref: "v0.7.4"
       resolved-ref: "17d77d49d1c211f6389a0f0dc6c3acf23c21aeb0"
-      url: "git@github.com:fluttercommunity/arcgis_map.git"
+      url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.4"
   arcgis_map_web:
@@ -43,7 +43,7 @@ packages:
       path: arcgis_map_web
       ref: "v0.7.4"
       resolved-ref: "17d77d49d1c211f6389a0f0dc6c3acf23c21aeb0"
-      url: "git@github.com:fluttercommunity/arcgis_map.git"
+      url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.4"
   async:

--- a/arcgis_map/pubspec.yaml
+++ b/arcgis_map/pubspec.yaml
@@ -13,19 +13,26 @@ dependencies:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_android
       ref: v0.7.0
-
   arcgis_map_ios:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_ios
       ref: v0.7.0
-
   arcgis_map_platform_interface:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
       ref: v0.7.0
-
+  arcgis_map_method_channel:
+    git:
+      url: git@github.com:phntmxyz/arcgis_map.git
+      path: arcgis_map_method_channel
+      ref: 0.7.0
+  arcgis_map_web:
+    git:
+      url: git@github.com:phntmxyz/arcgis_map.git
+      path: arcgis_map_web
+      ref: 0.7.0
   flutter:
     sdk: flutter
 

--- a/arcgis_map/pubspec.yaml
+++ b/arcgis_map/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map
 description: Esri ArcGIS Flutter map package.
-version: 0.7.3
+version: 0.7.4
 
 publish_to: none
 
@@ -12,27 +12,27 @@ dependencies:
     git:
       url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_android
-      ref: v0.7.3
+      ref: v0.7.4
   arcgis_map_ios:
     git:
       url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_ios
-      ref: v0.7.3
+      ref: v0.7.4
   arcgis_map_platform_interface:
     git:
       url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.3
+      ref: v0.7.4
   arcgis_map_method_channel:
     git:
       url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_method_channel
-      ref: v0.7.3
+      ref: v0.7.4
   arcgis_map_web:
     git:
       url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_web
-      ref: v0.7.3
+      ref: v0.7.4
   flutter:
     sdk: flutter
 

--- a/arcgis_map/pubspec.yaml
+++ b/arcgis_map/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map
 description: Esri ArcGIS Flutter map package.
-version: 0.7.0
+version: 0.7.1
 
 publish_to: none
 
@@ -12,42 +12,31 @@ dependencies:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_android
-      ref: v0.7.0
+      ref: v0.7.1
   arcgis_map_ios:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_ios
-      ref: v0.7.0
+      ref: v0.7.1
   arcgis_map_platform_interface:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.0
+      ref: v0.7.1
   arcgis_map_method_channel:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_method_channel
-      ref: 0.7.0
+      ref: v0.7.1
   arcgis_map_web:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_web
-      ref: 0.7.0
+      ref: v0.7.1
   flutter:
     sdk: flutter
 
 # Used to work locally on the package
-dependency_overrides:
-  arcgis_map_android:
-    path: ../arcgis_map_android
-  arcgis_map_ios:
-    path: ../arcgis_map_ios
-  arcgis_map_platform_interface:
-    path: ../arcgis_map_platform_interface
-  arcgis_map_method_channel:
-    path: ../arcgis_map_method_channel
-  arcgis_map_web:
-    path: ../arcgis_map_web
 
 dev_dependencies:
   flutter_lints: ^2.0.1

--- a/arcgis_map/pubspec.yaml
+++ b/arcgis_map/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map
 description: Esri ArcGIS Flutter map package.
-version: 0.9.0
+version: 0.7.0
 
 publish_to: none
 
@@ -12,19 +12,19 @@ dependencies:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_android
-      ref: main
+      ref: v0.7.0
 
   arcgis_map_ios:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_ios
-      ref: main
+      ref: v0.7.0
 
   arcgis_map_platform_interface:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: main
+      ref: v0.7.0
 
   flutter:
     sdk: flutter

--- a/arcgis_map/pubspec.yaml
+++ b/arcgis_map/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map
 description: Esri ArcGIS Flutter map package.
-version: 0.7.1
+version: 0.9.0
 
 publish_to: none
 
@@ -24,12 +24,23 @@ dependencies:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.1
+      ref: main
 
   flutter:
     sdk: flutter
 
 # Used to work locally on the package
+dependency_overrides:
+  arcgis_map_android:
+    path: ../arcgis_map_android
+  arcgis_map_ios:
+    path: ../arcgis_map_ios
+  arcgis_map_platform_interface:
+    path: ../arcgis_map_platform_interface
+  arcgis_map_method_channel:
+    path: ../arcgis_map_method_channel
+  arcgis_map_web:
+    path: ../arcgis_map_web
 
 dev_dependencies:
   flutter_lints: ^2.0.1

--- a/arcgis_map/pubspec.yaml
+++ b/arcgis_map/pubspec.yaml
@@ -10,27 +10,27 @@ environment:
 dependencies:
   arcgis_map_android:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_android
       ref: v0.7.3
   arcgis_map_ios:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_ios
       ref: v0.7.3
   arcgis_map_platform_interface:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
       ref: v0.7.3
   arcgis_map_method_channel:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_method_channel
       ref: v0.7.3
   arcgis_map_web:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_web
       ref: v0.7.3
   flutter:

--- a/arcgis_map/pubspec.yaml
+++ b/arcgis_map/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map
 description: Esri ArcGIS Flutter map package.
-version: 0.7.1
+version: 0.7.3
 
 publish_to: none
 
@@ -12,27 +12,27 @@ dependencies:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_android
-      ref: v0.7.1
+      ref: v0.7.3
   arcgis_map_ios:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_ios
-      ref: v0.7.1
+      ref: v0.7.3
   arcgis_map_platform_interface:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.1
+      ref: v0.7.3
   arcgis_map_method_channel:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_method_channel
-      ref: v0.7.1
+      ref: v0.7.3
   arcgis_map_web:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_web
-      ref: v0.7.1
+      ref: v0.7.3
   flutter:
     sdk: flutter
 

--- a/arcgis_map/pubspec.yaml
+++ b/arcgis_map/pubspec.yaml
@@ -10,27 +10,27 @@ environment:
 dependencies:
   arcgis_map_android:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_android
       ref: v0.7.4
   arcgis_map_ios:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_ios
       ref: v0.7.4
   arcgis_map_platform_interface:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
       ref: v0.7.4
   arcgis_map_method_channel:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_method_channel
       ref: v0.7.4
   arcgis_map_web:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_web
       ref: v0.7.4
   flutter:

--- a/arcgis_map/pubspec.yaml
+++ b/arcgis_map/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map
 description: Esri ArcGIS Flutter map package.
-version: 0.7.4
+version: 0.7.5
 
 publish_to: none
 
@@ -12,27 +12,27 @@ dependencies:
     git:
       url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_android
-      ref: v0.7.4
+      ref: v0.7.5
   arcgis_map_ios:
     git:
       url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_ios
-      ref: v0.7.4
+      ref: v0.7.5
   arcgis_map_platform_interface:
     git:
       url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.4
+      ref: v0.7.5
   arcgis_map_method_channel:
     git:
       url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_method_channel
-      ref: v0.7.4
+      ref: v0.7.5
   arcgis_map_web:
     git:
       url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_web
-      ref: v0.7.4
+      ref: v0.7.5
   flutter:
     sdk: flutter
 

--- a/arcgis_map_android/pubspec.lock
+++ b/arcgis_map_android/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: arcgis_map_method_channel
       ref: "v0.7.3"
       resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
-      url: "git@github.com:phntmxyz/arcgis_map.git"
+      url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.3"
   arcgis_map_platform_interface:
@@ -16,7 +16,7 @@ packages:
       path: arcgis_map_platform_interface
       ref: "v0.7.3"
       resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
-      url: "git@github.com:phntmxyz/arcgis_map.git"
+      url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.3"
   characters:

--- a/arcgis_map_android/pubspec.lock
+++ b/arcgis_map_android/pubspec.lock
@@ -4,17 +4,21 @@ packages:
   arcgis_map_method_channel:
     dependency: "direct main"
     description:
-      path: "../arcgis_map_method_channel"
-      relative: true
-    source: path
-    version: "0.7.0"
+      path: arcgis_map_method_channel
+      ref: "v0.7.3"
+      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      url: "git@github.com:phntmxyz/arcgis_map.git"
+    source: git
+    version: "0.7.3"
   arcgis_map_platform_interface:
     dependency: "direct main"
     description:
-      path: "../arcgis_map_platform_interface"
-      relative: true
-    source: path
-    version: "0.7.0"
+      path: arcgis_map_platform_interface
+      ref: "v0.7.3"
+      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      url: "git@github.com:phntmxyz/arcgis_map.git"
+    source: git
+    version: "0.7.3"
   characters:
     dependency: transitive
     description:

--- a/arcgis_map_android/pubspec.lock
+++ b/arcgis_map_android/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: arcgis_map_method_channel
       ref: "v0.7.4"
       resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
-      url: "git@github.com:fluttercommunity/arcgis_map.git"
+      url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.4"
   arcgis_map_platform_interface:
@@ -16,7 +16,7 @@ packages:
       path: arcgis_map_platform_interface
       ref: "v0.7.4"
       resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
-      url: "git@github.com:fluttercommunity/arcgis_map.git"
+      url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.4"
   characters:

--- a/arcgis_map_android/pubspec.lock
+++ b/arcgis_map_android/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       path: "../arcgis_map_method_channel"
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.7.0"
   arcgis_map_platform_interface:
     dependency: "direct main"
     description:
       path: "../arcgis_map_platform_interface"
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.7.0"
   characters:
     dependency: transitive
     description:

--- a/arcgis_map_android/pubspec.lock
+++ b/arcgis_map_android/pubspec.lock
@@ -5,20 +5,20 @@ packages:
     dependency: "direct main"
     description:
       path: arcgis_map_method_channel
-      ref: "v0.7.3"
-      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      ref: "v0.7.4"
+      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
       url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.3"
+    version: "0.7.4"
   arcgis_map_platform_interface:
     dependency: "direct main"
     description:
       path: arcgis_map_platform_interface
-      ref: "v0.7.3"
-      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      ref: "v0.7.4"
+      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
       url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.3"
+    version: "0.7.4"
   characters:
     dependency: transitive
     description:

--- a/arcgis_map_android/pubspec.lock
+++ b/arcgis_map_android/pubspec.lock
@@ -5,20 +5,20 @@ packages:
     dependency: "direct main"
     description:
       path: arcgis_map_method_channel
-      ref: "v0.7.4"
-      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
+      ref: "v0.7.5"
+      resolved-ref: f6f96a5fc8212c6b1700aa3b301cbffc388e197e
       url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.4"
+    version: "0.7.5"
   arcgis_map_platform_interface:
     dependency: "direct main"
     description:
       path: arcgis_map_platform_interface
-      ref: "v0.7.4"
-      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
+      ref: "v0.7.5"
+      resolved-ref: f6f96a5fc8212c6b1700aa3b301cbffc388e197e
       url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.4"
+    version: "0.7.5"
   characters:
     dependency: transitive
     description:

--- a/arcgis_map_android/pubspec.yaml
+++ b/arcgis_map_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_android
 description: Esri ArcGIS Flutter Android implementation.
-version: 0.7.1
+version: 0.7.3
 
 publish_to: none
 
@@ -12,12 +12,12 @@ dependencies:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.1
+      ref: v0.7.3
   arcgis_map_method_channel:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_method_channel
-      ref: v0.7.1
+      ref: v0.7.3
 
   flutter:
     sdk: flutter

--- a/arcgis_map_android/pubspec.yaml
+++ b/arcgis_map_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_android
 description: Esri ArcGIS Flutter Android implementation.
-version: 0.9.0
+version: 0.7.0
 
 publish_to: none
 
@@ -12,12 +12,12 @@ dependencies:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: main
+      ref: v0.7.0
   arcgis_map_method_channel:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_method_channel
-      ref: main
+      ref: v0.7.0
 
   flutter:
     sdk: flutter

--- a/arcgis_map_android/pubspec.yaml
+++ b/arcgis_map_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_android
 description: Esri ArcGIS Flutter Android implementation.
-version: 0.7.3
+version: 0.7.4
 
 publish_to: none
 
@@ -12,12 +12,12 @@ dependencies:
     git:
       url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.3
+      ref: v0.7.4
   arcgis_map_method_channel:
     git:
       url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_method_channel
-      ref: v0.7.3
+      ref: v0.7.4
 
   flutter:
     sdk: flutter

--- a/arcgis_map_android/pubspec.yaml
+++ b/arcgis_map_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_android
 description: Esri ArcGIS Flutter Android implementation.
-version: 0.7.0
+version: 0.7.1
 
 publish_to: none
 
@@ -12,12 +12,12 @@ dependencies:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.0
+      ref: v0.7.1
   arcgis_map_method_channel:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_method_channel
-      ref: v0.7.0
+      ref: v0.7.1
 
   flutter:
     sdk: flutter
@@ -26,11 +26,6 @@ dev_dependencies:
   flutter_lints: ^2.0.1
 
 # Used to work locally on the package
-dependency_overrides:
-  arcgis_map_method_channel:
-    path: ../arcgis_map_method_channel
-  arcgis_map_platform_interface:
-    path: ../arcgis_map_platform_interface
 
 flutter:
   plugin:

--- a/arcgis_map_android/pubspec.yaml
+++ b/arcgis_map_android/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
 dependencies:
   arcgis_map_platform_interface:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
       ref: v0.7.4
   arcgis_map_method_channel:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_method_channel
       ref: v0.7.4
 

--- a/arcgis_map_android/pubspec.yaml
+++ b/arcgis_map_android/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
 dependencies:
   arcgis_map_platform_interface:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
       ref: v0.7.3
   arcgis_map_method_channel:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_method_channel
       ref: v0.7.3
 

--- a/arcgis_map_android/pubspec.yaml
+++ b/arcgis_map_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_android
 description: Esri ArcGIS Flutter Android implementation.
-version: 0.7.4
+version: 0.7.5
 
 publish_to: none
 
@@ -12,12 +12,12 @@ dependencies:
     git:
       url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.4
+      ref: v0.7.5
   arcgis_map_method_channel:
     git:
       url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_method_channel
-      ref: v0.7.4
+      ref: v0.7.5
 
   flutter:
     sdk: flutter

--- a/arcgis_map_ios/pubspec.lock
+++ b/arcgis_map_ios/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: arcgis_map_method_channel
       ref: "v0.7.3"
       resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
-      url: "git@github.com:phntmxyz/arcgis_map.git"
+      url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.3"
   arcgis_map_platform_interface:
@@ -16,7 +16,7 @@ packages:
       path: arcgis_map_platform_interface
       ref: "v0.7.3"
       resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
-      url: "git@github.com:phntmxyz/arcgis_map.git"
+      url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.3"
   characters:

--- a/arcgis_map_ios/pubspec.lock
+++ b/arcgis_map_ios/pubspec.lock
@@ -4,17 +4,21 @@ packages:
   arcgis_map_method_channel:
     dependency: "direct main"
     description:
-      path: "../arcgis_map_method_channel"
-      relative: true
-    source: path
-    version: "0.7.0"
+      path: arcgis_map_method_channel
+      ref: "v0.7.3"
+      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      url: "git@github.com:phntmxyz/arcgis_map.git"
+    source: git
+    version: "0.7.3"
   arcgis_map_platform_interface:
     dependency: "direct main"
     description:
-      path: "../arcgis_map_platform_interface"
-      relative: true
-    source: path
-    version: "0.7.0"
+      path: arcgis_map_platform_interface
+      ref: "v0.7.3"
+      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      url: "git@github.com:phntmxyz/arcgis_map.git"
+    source: git
+    version: "0.7.3"
   characters:
     dependency: transitive
     description:

--- a/arcgis_map_ios/pubspec.lock
+++ b/arcgis_map_ios/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: arcgis_map_method_channel
       ref: "v0.7.4"
       resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
-      url: "git@github.com:fluttercommunity/arcgis_map.git"
+      url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.4"
   arcgis_map_platform_interface:
@@ -16,7 +16,7 @@ packages:
       path: arcgis_map_platform_interface
       ref: "v0.7.4"
       resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
-      url: "git@github.com:fluttercommunity/arcgis_map.git"
+      url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.4"
   characters:

--- a/arcgis_map_ios/pubspec.lock
+++ b/arcgis_map_ios/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       path: "../arcgis_map_method_channel"
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.7.0"
   arcgis_map_platform_interface:
     dependency: "direct main"
     description:
       path: "../arcgis_map_platform_interface"
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.7.0"
   characters:
     dependency: transitive
     description:

--- a/arcgis_map_ios/pubspec.lock
+++ b/arcgis_map_ios/pubspec.lock
@@ -5,20 +5,20 @@ packages:
     dependency: "direct main"
     description:
       path: arcgis_map_method_channel
-      ref: "v0.7.3"
-      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      ref: "v0.7.4"
+      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
       url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.3"
+    version: "0.7.4"
   arcgis_map_platform_interface:
     dependency: "direct main"
     description:
       path: arcgis_map_platform_interface
-      ref: "v0.7.3"
-      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      ref: "v0.7.4"
+      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
       url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.3"
+    version: "0.7.4"
   characters:
     dependency: transitive
     description:

--- a/arcgis_map_ios/pubspec.lock
+++ b/arcgis_map_ios/pubspec.lock
@@ -5,20 +5,20 @@ packages:
     dependency: "direct main"
     description:
       path: arcgis_map_method_channel
-      ref: "v0.7.4"
-      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
+      ref: "v0.7.5"
+      resolved-ref: f6f96a5fc8212c6b1700aa3b301cbffc388e197e
       url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.4"
+    version: "0.7.5"
   arcgis_map_platform_interface:
     dependency: "direct main"
     description:
       path: arcgis_map_platform_interface
-      ref: "v0.7.4"
-      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
+      ref: "v0.7.5"
+      resolved-ref: f6f96a5fc8212c6b1700aa3b301cbffc388e197e
       url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.4"
+    version: "0.7.5"
   characters:
     dependency: transitive
     description:

--- a/arcgis_map_ios/pubspec.yaml
+++ b/arcgis_map_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_ios
 description: Esri ArcGIS Flutter iOS implementation.
-version: 0.7.1
+version: 0.7.3
 
 publish_to: none
 
@@ -12,12 +12,12 @@ dependencies:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.1
+      ref: v0.7.3
   arcgis_map_method_channel:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_method_channel
-      ref: v0.7.1
+      ref: v0.7.3
 
   flutter:
     sdk: flutter

--- a/arcgis_map_ios/pubspec.yaml
+++ b/arcgis_map_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_ios
 description: Esri ArcGIS Flutter iOS implementation.
-version: 0.7.0
+version: 0.7.1
 
 publish_to: none
 
@@ -12,12 +12,12 @@ dependencies:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.0
+      ref: v0.7.1
   arcgis_map_method_channel:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_method_channel
-      ref: v0.7.0
+      ref: v0.7.1
 
   flutter:
     sdk: flutter
@@ -26,11 +26,6 @@ dev_dependencies:
   flutter_lints: ^2.0.1
 
 # Used to work locally on the package
-dependency_overrides:
-  arcgis_map_method_channel:
-    path: ../arcgis_map_method_channel
-  arcgis_map_platform_interface:
-    path: ../arcgis_map_platform_interface
 
 flutter:
   plugin:

--- a/arcgis_map_ios/pubspec.yaml
+++ b/arcgis_map_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_ios
 description: Esri ArcGIS Flutter iOS implementation.
-version: 0.7.3
+version: 0.7.4
 
 publish_to: none
 
@@ -12,12 +12,12 @@ dependencies:
     git:
       url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.3
+      ref: v0.7.4
   arcgis_map_method_channel:
     git:
       url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_method_channel
-      ref: v0.7.3
+      ref: v0.7.4
 
   flutter:
     sdk: flutter

--- a/arcgis_map_ios/pubspec.yaml
+++ b/arcgis_map_ios/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
 dependencies:
   arcgis_map_platform_interface:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
       ref: v0.7.4
   arcgis_map_method_channel:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_method_channel
       ref: v0.7.4
 

--- a/arcgis_map_ios/pubspec.yaml
+++ b/arcgis_map_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_ios
 description: Esri ArcGIS Flutter iOS implementation.
-version: 0.7.4
+version: 0.7.5
 
 publish_to: none
 
@@ -12,12 +12,12 @@ dependencies:
     git:
       url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.4
+      ref: v0.7.5
   arcgis_map_method_channel:
     git:
       url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_method_channel
-      ref: v0.7.4
+      ref: v0.7.5
 
   flutter:
     sdk: flutter

--- a/arcgis_map_ios/pubspec.yaml
+++ b/arcgis_map_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_ios
 description: Esri ArcGIS Flutter iOS implementation.
-version: 0.9.0
+version: 0.7.0
 
 publish_to: none
 
@@ -12,12 +12,12 @@ dependencies:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: main
+      ref: v0.7.0
   arcgis_map_method_channel:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_method_channel
-      ref: main
+      ref: v0.7.0
 
   flutter:
     sdk: flutter

--- a/arcgis_map_ios/pubspec.yaml
+++ b/arcgis_map_ios/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
 dependencies:
   arcgis_map_platform_interface:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
       ref: v0.7.3
   arcgis_map_method_channel:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_method_channel
       ref: v0.7.3
 

--- a/arcgis_map_method_channel/pubspec.lock
+++ b/arcgis_map_method_channel/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: arcgis_map_platform_interface
       ref: "v0.7.3"
       resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
-      url: "git@github.com:phntmxyz/arcgis_map.git"
+      url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.3"
   characters:

--- a/arcgis_map_method_channel/pubspec.lock
+++ b/arcgis_map_method_channel/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: arcgis_map_platform_interface
       ref: "v0.7.4"
       resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
-      url: "git@github.com:fluttercommunity/arcgis_map.git"
+      url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.4"
   characters:

--- a/arcgis_map_method_channel/pubspec.lock
+++ b/arcgis_map_method_channel/pubspec.lock
@@ -5,11 +5,11 @@ packages:
     dependency: "direct main"
     description:
       path: arcgis_map_platform_interface
-      ref: "v0.7.3"
-      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      ref: "v0.7.4"
+      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
       url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.3"
+    version: "0.7.4"
   characters:
     dependency: transitive
     description:

--- a/arcgis_map_method_channel/pubspec.lock
+++ b/arcgis_map_method_channel/pubspec.lock
@@ -4,10 +4,12 @@ packages:
   arcgis_map_platform_interface:
     dependency: "direct main"
     description:
-      path: "../arcgis_map_platform_interface"
-      relative: true
-    source: path
-    version: "0.7.0"
+      path: arcgis_map_platform_interface
+      ref: "v0.7.3"
+      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      url: "git@github.com:phntmxyz/arcgis_map.git"
+    source: git
+    version: "0.7.3"
   characters:
     dependency: transitive
     description:

--- a/arcgis_map_method_channel/pubspec.lock
+++ b/arcgis_map_method_channel/pubspec.lock
@@ -5,11 +5,11 @@ packages:
     dependency: "direct main"
     description:
       path: arcgis_map_platform_interface
-      ref: "v0.7.4"
-      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
+      ref: "v0.7.5"
+      resolved-ref: f6f96a5fc8212c6b1700aa3b301cbffc388e197e
       url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.4"
+    version: "0.7.5"
   characters:
     dependency: transitive
     description:

--- a/arcgis_map_method_channel/pubspec.lock
+++ b/arcgis_map_method_channel/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: "../arcgis_map_platform_interface"
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.7.0"
   characters:
     dependency: transitive
     description:

--- a/arcgis_map_method_channel/pubspec.yaml
+++ b/arcgis_map_method_channel/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_method_channel
 description: Esri ArcGIS Flutter method channel implementation.
-version: 0.7.1
+version: 0.7.3
 
 publish_to: none
 
@@ -12,7 +12,7 @@ dependencies:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.1
+      ref: v0.7.3
 
   flutter:
     sdk: flutter

--- a/arcgis_map_method_channel/pubspec.yaml
+++ b/arcgis_map_method_channel/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_method_channel
 description: Esri ArcGIS Flutter method channel implementation.
-version: 0.9.0
+version: 0.7.0
 
 publish_to: none
 
@@ -12,7 +12,7 @@ dependencies:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: main
+      ref: v0.7.0
 
   flutter:
     sdk: flutter

--- a/arcgis_map_method_channel/pubspec.yaml
+++ b/arcgis_map_method_channel/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_method_channel
 description: Esri ArcGIS Flutter method channel implementation.
-version: 0.7.0
+version: 0.7.1
 
 publish_to: none
 
@@ -12,7 +12,7 @@ dependencies:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.0
+      ref: v0.7.1
 
   flutter:
     sdk: flutter
@@ -21,6 +21,3 @@ dev_dependencies:
   flutter_lints: ^2.0.1
 
 # Used to work locally on the package
-dependency_overrides:
-  arcgis_map_platform_interface:
-    path: ../arcgis_map_platform_interface

--- a/arcgis_map_method_channel/pubspec.yaml
+++ b/arcgis_map_method_channel/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_method_channel
 description: Esri ArcGIS Flutter method channel implementation.
-version: 0.7.4
+version: 0.7.5
 
 publish_to: none
 
@@ -12,7 +12,7 @@ dependencies:
     git:
       url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.4
+      ref: v0.7.5
 
   flutter:
     sdk: flutter

--- a/arcgis_map_method_channel/pubspec.yaml
+++ b/arcgis_map_method_channel/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_method_channel
 description: Esri ArcGIS Flutter method channel implementation.
-version: 0.7.3
+version: 0.7.4
 
 publish_to: none
 
@@ -12,7 +12,7 @@ dependencies:
     git:
       url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.3
+      ref: v0.7.4
 
   flutter:
     sdk: flutter

--- a/arcgis_map_method_channel/pubspec.yaml
+++ b/arcgis_map_method_channel/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   arcgis_map_platform_interface:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
       ref: v0.7.4
 

--- a/arcgis_map_method_channel/pubspec.yaml
+++ b/arcgis_map_method_channel/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   arcgis_map_platform_interface:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
       ref: v0.7.3
 

--- a/arcgis_map_platform_interface/pubspec.yaml
+++ b/arcgis_map_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_platform_interface
 description: Esri ArcGIS Flutter platform interface.
-version: 0.7.1
+version: 0.9.0
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/arcgis_map_platform_interface/pubspec.yaml
+++ b/arcgis_map_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_platform_interface
 description: Esri ArcGIS Flutter platform interface.
-version: 0.7.4
+version: 0.7.5
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/arcgis_map_platform_interface/pubspec.yaml
+++ b/arcgis_map_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_platform_interface
 description: Esri ArcGIS Flutter platform interface.
-version: 0.7.0
+version: 0.7.1
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/arcgis_map_platform_interface/pubspec.yaml
+++ b/arcgis_map_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_platform_interface
 description: Esri ArcGIS Flutter platform interface.
-version: 0.7.3
+version: 0.7.4
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/arcgis_map_platform_interface/pubspec.yaml
+++ b/arcgis_map_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_platform_interface
 description: Esri ArcGIS Flutter platform interface.
-version: 0.7.1
+version: 0.7.3
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/arcgis_map_platform_interface/pubspec.yaml
+++ b/arcgis_map_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_platform_interface
 description: Esri ArcGIS Flutter platform interface.
-version: 0.9.0
+version: 0.7.0
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/arcgis_map_web/pubspec.lock
+++ b/arcgis_map_web/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: "../arcgis_map_platform_interface"
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.7.0"
   async:
     dependency: "direct main"
     description:

--- a/arcgis_map_web/pubspec.lock
+++ b/arcgis_map_web/pubspec.lock
@@ -5,11 +5,11 @@ packages:
     dependency: "direct main"
     description:
       path: arcgis_map_platform_interface
-      ref: "v0.7.4"
-      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
+      ref: "v0.7.5"
+      resolved-ref: f6f96a5fc8212c6b1700aa3b301cbffc388e197e
       url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.4"
+    version: "0.7.5"
   async:
     dependency: "direct main"
     description:

--- a/arcgis_map_web/pubspec.lock
+++ b/arcgis_map_web/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: arcgis_map_platform_interface
       ref: "v0.7.4"
       resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
-      url: "git@github.com:fluttercommunity/arcgis_map.git"
+      url: "https://github.com/fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.4"
   async:

--- a/arcgis_map_web/pubspec.lock
+++ b/arcgis_map_web/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: arcgis_map_platform_interface
       ref: "v0.7.3"
       resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
-      url: "git@github.com:phntmxyz/arcgis_map.git"
+      url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
     version: "0.7.3"
   async:

--- a/arcgis_map_web/pubspec.lock
+++ b/arcgis_map_web/pubspec.lock
@@ -4,12 +4,10 @@ packages:
   arcgis_map_platform_interface:
     dependency: "direct main"
     description:
-      path: arcgis_map_platform_interface
-      ref: "v0.7.1"
-      resolved-ref: bac1dcfeab607582f86ec8555262397b98c15c51
-      url: "git@github.com:phntmxyz/arcgis_map.git"
-    source: git
-    version: "0.7.1"
+      path: "../arcgis_map_platform_interface"
+      relative: true
+    source: path
+    version: "0.9.0"
   async:
     dependency: "direct main"
     description:

--- a/arcgis_map_web/pubspec.lock
+++ b/arcgis_map_web/pubspec.lock
@@ -5,11 +5,11 @@ packages:
     dependency: "direct main"
     description:
       path: arcgis_map_platform_interface
-      ref: "v0.7.3"
-      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      ref: "v0.7.4"
+      resolved-ref: "2b0c36ceb24ac690536c4a6da45388f04f83e3ec"
       url: "git@github.com:fluttercommunity/arcgis_map.git"
     source: git
-    version: "0.7.3"
+    version: "0.7.4"
   async:
     dependency: "direct main"
     description:

--- a/arcgis_map_web/pubspec.lock
+++ b/arcgis_map_web/pubspec.lock
@@ -4,10 +4,12 @@ packages:
   arcgis_map_platform_interface:
     dependency: "direct main"
     description:
-      path: "../arcgis_map_platform_interface"
-      relative: true
-    source: path
-    version: "0.7.0"
+      path: arcgis_map_platform_interface
+      ref: "v0.7.3"
+      resolved-ref: "4a6d5ba103a5b02de7dae14b10ad2b1fd66be6fa"
+      url: "git@github.com:phntmxyz/arcgis_map.git"
+    source: git
+    version: "0.7.3"
   async:
     dependency: "direct main"
     description:

--- a/arcgis_map_web/pubspec.yaml
+++ b/arcgis_map_web/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   arcgis_map_platform_interface:
     git:
-      url: git@github.com:fluttercommunity/arcgis_map.git
+      url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
       ref: v0.7.4
   async: ^2.9.0

--- a/arcgis_map_web/pubspec.yaml
+++ b/arcgis_map_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_web
 description: Esri ArcGIS Flutter web implementation.
-version: 0.7.1
+version: 0.9.0
 
 publish_to: none
 
@@ -12,7 +12,7 @@ dependencies:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.1
+      ref: main
   async: ^2.9.0
 
   flutter:
@@ -25,6 +25,9 @@ dev_dependencies:
   lint: ^2.0.0
 
 # Used to work locally on the package
+dependency_overrides:
+  arcgis_map_platform_interface:
+    path: ../arcgis_map_platform_interface
 
 flutter:
   plugin:

--- a/arcgis_map_web/pubspec.yaml
+++ b/arcgis_map_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_web
 description: Esri ArcGIS Flutter web implementation.
-version: 0.9.0
+version: 0.7.0
 
 publish_to: none
 
@@ -12,7 +12,7 @@ dependencies:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: main
+      ref: v0.7.0
   async: ^2.9.0
 
   flutter:

--- a/arcgis_map_web/pubspec.yaml
+++ b/arcgis_map_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_web
 description: Esri ArcGIS Flutter web implementation.
-version: 0.7.3
+version: 0.7.4
 
 publish_to: none
 
@@ -12,7 +12,7 @@ dependencies:
     git:
       url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.3
+      ref: v0.7.4
   async: ^2.9.0
 
   flutter:

--- a/arcgis_map_web/pubspec.yaml
+++ b/arcgis_map_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_web
 description: Esri ArcGIS Flutter web implementation.
-version: 0.7.4
+version: 0.7.5
 
 publish_to: none
 
@@ -12,7 +12,7 @@ dependencies:
     git:
       url: https://github.com/fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.4
+      ref: v0.7.5
   async: ^2.9.0
 
   flutter:

--- a/arcgis_map_web/pubspec.yaml
+++ b/arcgis_map_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_web
 description: Esri ArcGIS Flutter web implementation.
-version: 0.7.0
+version: 0.7.1
 
 publish_to: none
 
@@ -12,7 +12,7 @@ dependencies:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.0
+      ref: v0.7.1
   async: ^2.9.0
 
   flutter:
@@ -25,9 +25,6 @@ dev_dependencies:
   lint: ^2.0.0
 
 # Used to work locally on the package
-dependency_overrides:
-  arcgis_map_platform_interface:
-    path: ../arcgis_map_platform_interface
 
 flutter:
   plugin:

--- a/arcgis_map_web/pubspec.yaml
+++ b/arcgis_map_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_map_web
 description: Esri ArcGIS Flutter web implementation.
-version: 0.7.1
+version: 0.7.3
 
 publish_to: none
 
@@ -12,7 +12,7 @@ dependencies:
     git:
       url: git@github.com:phntmxyz/arcgis_map.git
       path: arcgis_map_platform_interface
-      ref: v0.7.1
+      ref: v0.7.3
   async: ^2.9.0
 
   flutter:

--- a/arcgis_map_web/pubspec.yaml
+++ b/arcgis_map_web/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   arcgis_map_platform_interface:
     git:
-      url: git@github.com:phntmxyz/arcgis_map.git
+      url: git@github.com:fluttercommunity/arcgis_map.git
       path: arcgis_map_platform_interface
       ref: v0.7.3
   async: ^2.9.0


### PR DESCRIPTION
## Changes

- [x] Fixes the `am release` command.
- [x] Releases a new tag with the `v0.7.5` tag.

## Comments
Normally, the branch that is used for release, is not merged to the main branch, because the dependency overrides needed for the development of the package are removed with the `am release` command.
In this case we will merge this brach and then restore the dependency overrides in `main` with a follow-up PR.