### PR TITLE
remove redundant call to stopLocationDataSource in ArcgisMapView dein…

### DIFF
--- a/arcgis_map_sdk_ios/ios/arcgis_map_sdk_ios/Sources/arcgis_map_sdk_ios/ArcgisMapView.swift
+++ b/arcgis_map_sdk_ios/ios/arcgis_map_sdk_ios/Sources/arcgis_map_sdk_ios/ArcgisMapView.swift
@@ -622,7 +622,6 @@ class ArcgisMapView: NSObject, FlutterPlatformView {
         mapContentView.viewModel.onLoadStatusChanged = nil
         mapContentView.viewModel.onViewInit = nil
         mapContentView.viewModel.mapViewProxy = nil
-        mapContentView.viewModel.stopLocationDataSource()
         
         zoomEventChannel.setStreamHandler(nil)
         centerPositionEventChannel.setStreamHandler(nil)


### PR DESCRIPTION
### Problem
stopLocationDataSource() was called twice—in MapContentView.onDisappear and ArcgisMapView.deinit—causing a race during SwiftUI teardown.

### Solution
Remove the call from ArcgisMapView.deinit and keep it only in MapContentView.onDisappear.
Official ArcGIS SwiftUI samples stop the location data source in .onDisappear as well.