### PR TITLE
fix-arcgis-controller-not-created

### DIFF
--- a/arcgis_map_sdk/lib/src/arcgis_map_sdk.dart
+++ b/arcgis_map_sdk/lib/src/arcgis_map_sdk.dart
@@ -86,7 +86,7 @@ class ArcgisMap extends StatefulWidget {
 
 class _ArcgisMapState extends State<ArcgisMap> {
   final int _mapId = _nextMapCreationId++;
-  late ArcgisMapController controller;
+  ArcgisMapController? controller;
 
   late ArcgisMapOptions _arcgisMapOptions = ArcgisMapOptions(
     apiKey: widget.apiKey,
@@ -117,7 +117,7 @@ class _ArcgisMapState extends State<ArcgisMap> {
 
   Future<void> onPlatformViewCreated(int id) async {
     controller = await ArcgisMapController.init(id);
-    widget.onMapCreated?.call(controller);
+    widget.onMapCreated?.call(controller!);
   }
 
   @override
@@ -139,11 +139,11 @@ class _ArcgisMapState extends State<ArcgisMap> {
   void didUpdateWidget(ArcgisMap oldWidget) {
     super.didUpdateWidget(oldWidget);
     if ((widget.basemap != null) && oldWidget.basemap != widget.basemap) {
-      controller.toggleBaseMap(baseMap: widget.basemap!);
+      controller?.toggleBaseMap(baseMap: widget.basemap!);
     }
     if (widget.isAttributionTextVisible != null &&
         widget.isAttributionTextVisible != oldWidget.isAttributionTextVisible) {
-      controller.updateIsAttributionTextVisible(
+      controller?.updateIsAttributionTextVisible(
         widget.isAttributionTextVisible!,
       );
     }
@@ -185,7 +185,7 @@ class _ArcgisMapState extends State<ArcgisMap> {
 
   @override
   void dispose() {
-    controller.dispose();
+    controller?.dispose();
     super.dispose();
   }
 }


### PR DESCRIPTION
This PR fixes a bug crash where the controller might be disposed (or updated) without it beeing created in the first place.

```
The following LateError was thrown while finalizing the widget tree:
LateInitializationError: Field 'controller' has not been initialized.

When the exception was thrown, this was the stack:
#0      _ArcgisMapState.controller (package:arcgis_map_sdk/src/arcgis_map_sdk.dart)
#1      _ArcgisMapState.dispose (package:arcgis_map_sdk/src/arcgis_map_sdk.dart:188:5)
#2      StatefulElement.unmount (package:flutter/src/widgets/framework.dart:5922:11)
#3      _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2075:13)
```