### PR TITLE
feature/improve-error-message-dispose

### DIFF
--- a/arcgis_map_sdk_android/android/src/main/kotlin/dev/fluttercommunity/arcgis_map_sdk_android/ArcgisMapView.kt
+++ b/arcgis_map_sdk_android/android/src/main/kotlin/dev/fluttercommunity/arcgis_map_sdk_android/ArcgisMapView.kt
@@ -168,6 +168,12 @@ internal class ArcgisMapView(
 
     private fun setupMethodChannel() {
         methodChannel.setMethodCallHandler { call, result ->
+            if (call.method == "dispose") {
+                // Only used on iOS for now. No need to cleanup anything on android
+                result.success(true)
+                return@setMethodCallHandler
+            }
+
             if (isDisposed) {
                 result.error("disposed", "Map called with ${call.method} but ArcgisMapView has been disposed", null)
                 return@setMethodCallHandler
@@ -220,8 +226,6 @@ internal class ArcgisMapView(
 
                 "export_image" -> onExportImage(result)
 
-                "dispose" -> onDispose(result)
-
                 else -> result.notImplemented()
             }
         }
@@ -257,11 +261,6 @@ internal class ArcgisMapView(
                 result.finishWithError(e)
             }
         }
-    }
-
-    private fun onDispose(result: MethodChannel.Result) {
-        // Only used on iOS for now. No need to cleanup anything on android
-        result.success(true)
     }
 
     private fun onSetLocationDisplayDefaultSymbol(call: MethodCall, result: MethodChannel.Result) {

--- a/arcgis_map_sdk_android/android/src/main/kotlin/dev/fluttercommunity/arcgis_map_sdk_android/ArcgisMapView.kt
+++ b/arcgis_map_sdk_android/android/src/main/kotlin/dev/fluttercommunity/arcgis_map_sdk_android/ArcgisMapView.kt
@@ -169,7 +169,7 @@ internal class ArcgisMapView(
     private fun setupMethodChannel() {
         methodChannel.setMethodCallHandler { call, result ->
             if (isDisposed) {
-                result.error("disposed", "ArcgisMapView has been disposed", null)
+                result.error("disposed", "Map called with ${call.method} but ArcgisMapView has been disposed", null)
                 return@setMethodCallHandler
             }
             when (call.method) {


### PR DESCRIPTION
 Fix Android handling of the `dispose` method when the map view has already been disposed.
 
Previously, Android checked `isDisposed` before routing the method call, which caused `dispose` to return an error instead of succeeding. This change handles `dispose` first and keeps it as a no-op success on Android, matching the intended behavior.
 
 ## Changes
 
 - Handle `dispose` before the disposed-state guard in `ArcgisMapView`
 - Remove the now-unused `onDispose` helper
 - Improve the disposed error message to include the attempted method name
